### PR TITLE
Synchronize the location and origin trailing '/'

### DIFF
--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -22,7 +22,12 @@ class NginxConfig
     json["proxies"].each do |loc, hash|
       evaled_origin = NginxConfigUtil.interpolate(hash['origin'], ENV)
       if evaled_origin != "/"
-        json["proxies"][loc].merge!("origin" => evaled_origin + "/")
+        if (loc.end_with?("/") && !evaled_origin.end_with?("/"))
+          evaled_origin += "/"
+        elsif (!loc.end_with?("/") && evaled_origin.end_with?("/"))
+          evaled_origin = evaled_origin.chomp("/")
+        end
+        json["proxies"][loc].merge!("origin" => evaled_origin)
       end
 
       uri = URI(evaled_origin)

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -91,7 +91,7 @@ http {
   # fallback proxy named match
   <% proxies.each do |location, hash| %>
     location @<%= location %> {
-      rewrite ^<%= location %>(.*)$ <%= hash['path'] %>/$1 break;
+      rewrite ^<%= location %>(.*)$ <%= hash['path'] %>$1 break;
       proxy_pass <%= hash['host'] %>;
     }
   <% end %>


### PR DESCRIPTION
If the location ends with one, and the origin doesn't: add a '/' to the origin.
If the location does not end with a slash, but the origin does: remove the trailing slash from the origin.

---

This is one way of fixing/improving https://github.com/hone/heroku-buildpack-static/issues/29

I'm not 100% sure here, maybe the better approach would be to just remove any automatic slash handling. With this change it is at least "consistent" what is happening.
