### PR TITLE
Enable the `proxy_ssl_server_name` option

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -80,6 +80,7 @@ http {
   <% proxies.each do |location, hash| %>
     location <%= location %> {
       proxy_pass <%= hash['origin'] %>;
+      proxy_ssl_server_name on;
     }
   <% end %>
 


### PR DESCRIPTION
This fixes https://github.com/hone/heroku-buildpack-static/issues/31

Note that this is currently on top of https://github.com/hone/heroku-buildpack-static/pull/30, but that isn't required.