### PR TITLE
Send typical proxy headers

### DIFF
--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -8,7 +8,8 @@ class NginxConfig
     encoding: "UTF-8",
     clean_urls: false,
     https_only: false,
-    worker_connections: 512
+    worker_connections: 512,
+    headers: []
   }
 
   def initialize(json_file)
@@ -29,6 +30,7 @@ class NginxConfig
       json["proxies"][loc]["path"] = uri.path
       uri.path = ""
       json["proxies"][loc]["host"] = uri.to_s
+      json["proxies"][loc]["headers"] = hash["headers"] || DEFAULT[:headers]
     end
     json["clean_urls"] ||= DEFAULT[:clean_urls]
     json["https_only"] ||= DEFAULT[:https_only]

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -80,6 +80,19 @@ http {
   <% proxies.each do |location, hash| %>
     location <%= location %> {
       proxy_pass <%= hash['origin'] %>;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_set_header Host $proxy_host;
+    <% if hash['headers'].any? { |s| s.casecmp('x-forwarded-proto') == 0 } %>
+      proxy_set_header X-Forwarded-Proto $scheme;
+    <% end %>
+    <% if hash['headers'].any? { |s| s.casecmp('x-forwarded-for') == 0 } %>
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    <% end %>
+    <% if hash['headers'].any? { |s| s.casecmp('x-forwarded-port') == 0 } %>
+      proxy_set_header X-Forwarded-Port $server_port;
+    <% end %>
     }
   <% end %>
 

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -93,6 +93,9 @@ http {
     <% if hash['headers'].any? { |s| s.casecmp('x-forwarded-port') == 0 } %>
       proxy_set_header X-Forwarded-Port $server_port;
     <% end %>
+    <% if hash['headers'].any? { |s| s.casecmp('x-request-start') == 0 } %>
+      proxy_set_header X-Request-Start "t=$msec";
+    <% end %>
     }
   <% end %>
 


### PR DESCRIPTION
It would be nice if the proxy logic would send over some headers to the origin server:
1. HTTP/1.1 usage
2. `X-Forwarded-For`, `X-Forwarded-Proto`, `X-Forwarded-Port` headers, so the origin can understand the original source of the request
3. `X-Request-Start` so it is possible to track timings of the requests from the beginning

Note that I made the X-headers conditional on a new 'headers' configuration option, mainly because having the `X-Forwarded-Proto` seems to break origins on AWS cloudfront some reason.

This is on top of https://github.com/hone/heroku-buildpack-static/pull/32, although that would not be required.
