### PR TITLE
Add a HSTS header when 'https_only' is set

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -62,6 +62,8 @@ http {
     if ($http_x_forwarded_proto != "https") {
       return 301 https://$host$uri;
     }
+    # XXX: Should this be configurable? 'preload' and 'includeSubDomains' tags are quite likely helpful for some apps.
+    add_header Strict-Transport-Security max-age=31536000;
   <% end %>
 
   <% routes.each do |route, path| %>


### PR DESCRIPTION
If the site is configured to only be reachable via HTTPS, then it really makes sense to also tell the browser to remember that choice using the Strict-Transport-Security header (https://tools.ietf.org/html/rfc6797).

Note that the value chosen here is fairly long, so when just playing with `https_only` people might get confused when the browser forces HTTPS even when they switch off that setting again. Maybe it would be really be sensible to either:
- use a different option
- use a tri-state option for `https_only`: true, false, 'yes-including-hsts-i-really-mean-it'

What do you think?
