### PR TITLE
allowing for env override for "htts_only"

### DIFF
--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -32,7 +32,7 @@ class NginxConfig
     end
 
     json["clean_urls"] ||= DEFAULT[:clean_urls]
-    json["https_only"] ||= DEFAULT[:https_only]
+    json["https_only"] ||= ENV['STATIC_HTTPS_ONLY'] || DEFAULT[:https_only]
 
     json["routes"] ||= {}
     json["routes"] = NginxConfigUtil.parse_routes(json["routes"])

--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -32,7 +32,10 @@ class NginxConfig
     end
 
     json["clean_urls"] ||= DEFAULT[:clean_urls]
-    json["https_only"] ||= ENV['STATIC_HTTPS_ONLY'] || DEFAULT[:https_only]
+    
+    # use setting from env if set
+    json["https_only"] = ENV['STATIC_HTTPS_ONLY'] if ENV['STATIC_HTTPS_ONLY']
+    json["https_only"] ||= DEFAULT[:https_only]
 
     json["routes"] ||= {}
     json["routes"] = NginxConfigUtil.parse_routes(json["routes"])


### PR DESCRIPTION
For non-prod environments, it would be helpful to override this value via the environment. Especially in dogwood, where a custom domain is required for https.
