### PR TITLE
Add the ability to configure client_max_body_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ This allows you to specify a character set for your text assets (HTML, Javascrip
 }
 ```
 
+#### NGINX Configuration
+#### Client Max Body Size
+By default, nginx has a default max body size of 1 megabyte. Any request above this size (e.g. uploading a 2m file) will result in a `413 Request Entity too Large` error. You can configure this value by setting `max_body_size:`
+
+```json
+{
+  "max_body_size": "10m"
+}
+```
+The size setting follows nginx's convention of bytes, kilobytes and megabytes (1024, 8k, 1m).
+
 #### Clean URLs
 For SEO purposes, you can drop the `.html` extension from URLs for say a blog site. This means users could go to `/foo` instead of `/foo.html`.
 

--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -8,6 +8,7 @@ class NginxConfig
     encoding: "UTF-8",
     clean_urls: false,
     https_only: false,
+    max_body_size: "1M",
     worker_connections: 512
   }
 
@@ -33,6 +34,7 @@ class NginxConfig
 
     json["clean_urls"] ||= DEFAULT[:clean_urls]
     json["https_only"] ||= DEFAULT[:https_only]
+    json["max_body_size"] ||= DEFAULT[:max_body_size]
 
     json["routes"] ||= {}
     json["routes"] = NginxConfigUtil.parse_routes(json["routes"])

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -38,6 +38,7 @@ http {
     port_in_redirect off;
     keepalive_timeout 5;
     root <%= root %>;
+    client_max_body_size <%= max_body_size %>;
   <% if error_page %>
     error_page 404 500 /<%= error_page %>;
   <% end %>


### PR DESCRIPTION
## Background

By default, nginx uses a maximum of `1m` for `client_max_body_size`. This means requests above this will receive the `413 Request Entity Too Large` error. 

In my use case, this happened during a resume upload in our job application tracking app, which uses nginx to proxy requests and avoid CORs. 
## What this does
- Expose `client_max_body_size` to a configurable value under the `server` part of the config. This means that it's a global setting.
- Expose `max_body_size` in `static.json` so you can set the value. It's just taken as a string. 
- Update docs
## Need help
- [ ] Happy to add a test case but need some direction on what to test. Awesome if there's an example in the current test suite to follow. 
