### PR TITLE
proxy_ssl_server_name on on fallback proxy

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -94,6 +94,7 @@ http {
     location @<%= location %> {
       rewrite ^<%= location %>(.*)$ <%= hash['path'] %>/$1 break;
       proxy_pass <%= hash['host'] %>;
+      proxy_ssl_server_name on;
     }
   <% end %>
 


### PR DESCRIPTION
This is basically the same fix as #32, which missed the proxy_ssl_server_name option for the fallback proxy location, so requests to the backend secured via ssl with sni failed.

PS: I dont really get why any request would hit the fallback proxy location. It would be great if somebody could point that out to me 😉 
