### PR TITLE
Add support to prerender service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 .bundle/
+.idea

--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -44,6 +44,7 @@ class NginxConfig
 
     json["error_page"] ||= nil
     json["debug"] ||= ENV['STATIC_DEBUG']
+    json["prerender"] ||= nil
     json.each do |key, value|
       self.class.send(:define_method, key) { value }
     end

--- a/scripts/config/make-config
+++ b/scripts/config/make-config
@@ -4,9 +4,15 @@ require 'fileutils'
 require 'erb'
 require_relative 'lib/nginx_config'
 
-TEMPLATE     = File.join(File.dirname(__FILE__), 'templates/nginx.conf.erb')
-USER_CONFIG  = 'static.json'
-NGINX_CONFIG = 'config/nginx.conf'
+TEMPLATE               = File.join(File.dirname(__FILE__), 'templates/nginx.conf.erb')
+TEMPLATE_PRERENDER     = File.join(File.dirname(__FILE__), 'templates/prerender.conf.erb')
+USER_CONFIG            = 'static.json'
+NGINX_CONFIG           = 'config/nginx.conf'
+PRERENDER_CONFIG       = 'config/prerender.conf'
 
-erb = ERB.new(File.read(TEMPLATE)).result(NginxConfig.new(USER_CONFIG).context)
+context = NginxConfig.new(USER_CONFIG).context
+erb = ERB.new(File.read(TEMPLATE)).result(context)
 File.write(NGINX_CONFIG, erb)
+
+erb = ERB.new(File.read(TEMPLATE_PRERENDER)).result(context)
+File.write(PRERENDER_CONFIG, erb)

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -45,31 +45,39 @@ http {
     location / {
       mruby_post_read_handler /app/bin/config/lib/ngx_mruby/headers.rb cache;
       mruby_set $fallback /app/bin/config/lib/ngx_mruby/routes_fallback.rb cache;
-    <% if clean_urls %>
+    <% if prerender %>
+      try_files $uri @prerender;
+    <% elsif clean_urls %>
       try_files $uri $uri/ $uri.html $fallback;
     <% else %>
       try_files $uri $uri/ $fallback;
     <% end %>
     }
 
-  <% if clean_urls %>
-    location ~ \.html$ {
-      try_files $uri =404;
-    }
-  <% end %>
+    <% if prerender %>
+      include prerender.conf;
+    <% end %>
 
-  <% if https_only %>
-    if ($http_x_forwarded_proto != "https") {
-      return 301 https://$host$request_uri;
-    }
-  <% end %>
+    <% if clean_urls %>
+      location ~ \.html$ {
+        try_files $uri =404;
+      }
+    <% end %>
+
+    <% if https_only %>
+      if ($http_x_forwarded_proto != "https") {
+        return 301 https://$host$request_uri;
+      }
+    <% end %>
 
   <% routes.each do |route, path| %>
     location ~ ^<%= route %>$ {
       set $route <%= route %>;
       mruby_set $path /app/bin/config/lib/ngx_mruby/routes_path.rb cache;
       mruby_set $fallback /app/bin/config/lib/ngx_mruby/routes_fallback.rb cache;
-    <% if clean_urls %>
+    <% if prerender %>
+      try_files $uri @prerender;
+    <% elsif clean_urls %>
       try_files $uri $uri/ /$uri.html $path $fallback;
     <% else %>
       try_files $uri $path $fallback;
@@ -94,6 +102,7 @@ http {
     location @<%= location %> {
       rewrite ^<%= location %>(.*)$ <%= hash['path'] %>/$1 break;
       proxy_pass <%= hash['host'] %>;
+      proxy_ssl_server_name on;
     }
   <% end %>
 

--- a/scripts/config/templates/prerender.conf.erb
+++ b/scripts/config/templates/prerender.conf.erb
@@ -1,0 +1,35 @@
+location @prerender {
+  proxy_set_header X-Prerender-Token <%= prerender['token'] %>;
+  set $prerender 0;
+
+  if ($http_user_agent ~* "baiduspider|twitterbot|facebookexternalhit|Google.*snippet|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator") {
+    set $prerender 1;
+  }
+  if ($args ~ "_escaped_fragment_") {
+    set $prerender 1;
+  }
+  if ($http_user_agent ~ "Prerender") {
+    set $prerender 0;
+  }
+  if ($uri ~* "\.(js|css|json|xml|less|png|jpg|jpeg|gif|pdf|doc|txt|ico|rss|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent|ttf|woff|svg|eot)") {
+    set $prerender 0;
+  }
+
+  #resolve using Google's DNS server to force DNS resolution and prevent caching of IPs
+  resolver 8.8.8.8;
+
+  if ($prerender = 1) {
+    #setting prerender as a variable forces DNS resolution since nginx caches IPs
+    #and doesnt play well with load balancing
+    set $prerender <%= prerender['server_name'] %>;
+    <% if https_only %>
+      rewrite .* /https://$host$request_uri? break;
+    <% else %>
+      rewrite .* /$scheme://$host$request_uri? break;
+    <% end %>
+    proxy_pass https://$prerender;
+  }
+  if ($prerender = 0) {
+    rewrite .* /index.html break;
+  }
+}


### PR DESCRIPTION
This PR add support to [prerender](https://prerender.io) service and allows single page web application to be crawled perfectly by search engines.
This is a first implementation, improvement are welcome!
Configuration of static.json file:

``` javascript
  "prerender": {
    "token": "your_secret_key",
    "server_name": "your_server_name"
  }
```
- [ ] Add unit test
- [ ] Update readme with configuration
