### PR TITLE
handle proxy redirects even if the scheme doesn't match

### DIFF
--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -29,6 +29,9 @@ class NginxConfig
       json["proxies"][loc]["path"] = uri.path
       uri.path = ""
       json["proxies"][loc]["host"] = uri.to_s
+      redirect_scheme = uri.scheme == "https" ? "http" : "https"
+      json["proxies"][loc]["redirect"] = uri.dup.tap {|u| u.scheme = redirect_scheme }.to_s
+      json["proxies"][loc]["redirect"] += "/" if !uri.to_s.end_with?("/")
     end
 
     json["clean_urls"] ||= DEFAULT[:clean_urls]

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -81,6 +81,8 @@ http {
     location <%= location %> {
       proxy_pass <%= hash['origin'] %>;
       proxy_ssl_server_name on;
+      proxy_redirect default;
+      proxy_redirect <%= hash["redirect"] %>  <%= location %>;
     }
   <% end %>
 
@@ -95,6 +97,8 @@ http {
       rewrite ^<%= location %>(.*)$ <%= hash['path'] %>/$1 break;
       proxy_pass <%= hash['host'] %>;
       proxy_ssl_server_name on;
+      proxy_redirect default;
+      proxy_redirect <%= hash["redirect"] %>  <%= location %>;
     }
   <% end %>
 


### PR DESCRIPTION
Normally, when receiving a `Location` header, nginx will rewrite it to reference a URL if it matches the `proxy_pass`. This breaks when the scheme changes, since `proxy_pass` can have a scheme. For instance, if you have a proxy: "https://www.foo.com", but the `Location` on a redirect from that site returns "http://www.foo.com" nginx won't rewrite the URL. This fixes it by specifying the redirect for both http and https.