### PR TITLE
https_only happens over proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ when accessing `/foo`, `X-Foo` will have the value `"foo"` and `X-Bar` will not 
 
 ### Route Ordering
 
+* HTTPS redirect
 * Root Files
 * Clean URLs
 * Proxies

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -80,19 +80,6 @@ http {
     }
   <% end %>
 
-  <% proxies.each do |location, hash| %>
-    set $<%= hash['name'] %> <%= hash['host'] %>;
-    location <%= location %> {
-      rewrite ^<%= location %>/?(.*) <%= hash['path'] %>/$1 break;
-      proxy_pass $<%= hash['name'] %>;
-      proxy_ssl_server_name on;
-      # handle Location rewrites from the proxy properly
-      <% %w(http https).each do |scheme| %>
-      proxy_redirect <%= hash["redirect_#{scheme}"] %> <%= location %>;
-      <% end %>
-    }
-  <% end %>
-
   # need this b/c setting $fallback to =404 will try #{root}=404 instead of returning a 404
   location @404 {
     return 404;
@@ -100,6 +87,7 @@ http {
 
   # fallback proxy named match
   <% proxies.each do |location, hash| %>
+    set $<%= hash['name'] %> <%= hash['host'] %>;
     location @<%= location %> {
       rewrite ^<%= location %>/?(.*)$ <%= hash['path'] %>/$1 break;
       # can reuse variable set above

--- a/spec/fixtures/redirects_https_only/public_html/index.html
+++ b/spec/fixtures/redirects_https_only/public_html/index.html
@@ -1,0 +1,1 @@
+hello world

--- a/spec/fixtures/redirects_https_only/static.json
+++ b/spec/fixtures/redirects_https_only/static.json
@@ -1,0 +1,9 @@
+{
+  "redirects": {
+    "/old/gone": {
+      "url": "/",
+      "status": 302
+    }
+  },
+  "https_only": true
+}


### PR DESCRIPTION
Fixes #64.

Remove the `proxies` section since it was overriding the `if` block.