### PR TITLE
add logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ For SEO purposes, you can drop the `.html` extension from URLs for say a blog si
 
 By default this is set to `false`.
 
+
+#### Logging
+You can disable the access log and change the severity level for the error log.
+
+```json
+{
+  "logging": {
+    "access": false,
+    "error": "warn"
+  }
+}
+```
+
+By default `access` is set to `true` and `error` is set to `error`.
+
+
 #### Custom Routes
 You can define custom routes that combine to a single file. This allows you to preserve routing for a single page web application. The following operators are supported:
 

--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -9,7 +9,11 @@ class NginxConfig
     clean_urls: false,
     https_only: false,
     worker_connections: 512,
-    resolver: "8.8.8.8"
+    resolver: "8.8.8.8",
+    logging: {
+      "access" => true,
+      "error" => "error"
+    }
   }
 
   def initialize(json_file)
@@ -51,6 +55,9 @@ class NginxConfig
 
     json["error_page"] ||= nil
     json["debug"] ||= ENV['STATIC_DEBUG']
+
+    logging = json["logging"] || {}
+    json["logging"] = DEFAULT[:logging].merge(logging)
 
     nameservers = []
     if File.exist?("/etc/resolv.conf")

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -17,12 +17,17 @@ http {
 
   server_tokens off;
 
-  access_log  logs/access.log;
+<% if logging.fetch('access') %>
+  access_log logs/access.log;
+<% else %>
+  access_log off;
+<% end %>
+
 <% if debug %>
   error_log stderr debug;
   rewrite_log on;
 <% else %>
-  error_log   stderr;
+  error_log stderr <%= logging.fetch('error') %>;
 <% end %>
 
   include mime.types;

--- a/spec/fixtures/logging_access_off/public_html/index.html
+++ b/spec/fixtures/logging_access_off/public_html/index.html
@@ -1,0 +1,1 @@
+hello world

--- a/spec/fixtures/logging_access_off/static.json
+++ b/spec/fixtures/logging_access_off/static.json
@@ -1,0 +1,5 @@
+{
+  "logging": {
+    "access": false
+  }
+}

--- a/spec/fixtures/logging_error_level/public_html/index.html
+++ b/spec/fixtures/logging_error_level/public_html/index.html
@@ -1,0 +1,1 @@
+hello world

--- a/spec/fixtures/logging_error_level/static.json
+++ b/spec/fixtures/logging_error_level/static.json
@@ -1,0 +1,5 @@
+{
+  "logging": {
+    "error": "warn"
+  }
+}


### PR DESCRIPTION
For HIPAA and other compliance work, we need the ability to remove access logs from going into `STDOUT`. Access logs can contain tokens and other identify information.

Instead of just adding just another option for turning logging on/off, let's group the logging pieces into their own namespace. We also have error logs already. Previously, you could only access the error log when using the hidden `debug` option. This changes debug and will replace it.

```
```json
{
  "logging": {
    "access": false,
    "error": "warn"
  }
}
```