### PR TITLE
Makes config copying idempotent

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,8 +25,7 @@ fetch_nginx_tarball() {
 mkdir -p $build_dir/bin
 $(fetch_nginx_tarball) | tar xzC $build_dir/bin
 nginx_version=$($build_dir/bin/nginx-$STACK -V 2>&1 | head -1 | awk '{ print $NF }')
-cp -a $bp_dir/scripts/boot $build_dir/bin/boot
-cp -a $bp_dir/scripts/config $build_dir/bin/config
+cp -a $bp_dir/scripts/{boot,config} -t $build_dir/bin/
 echo "-----> Installed ${nginx_version} to /app/bin"
 
 mkdir -p $build_dir/config


### PR DESCRIPTION
I need to use few features that not yet merged to master So I fork this buildpack, merge required changes and have following config on heroku:
```
$ heroku buildpacks
=== my-app Buildpack URLs
1. https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/emberjs.tgz
2. https://github.com/budnik/heroku-buildpack-static.git
```
As [emberjs](https://github.com/heroku/heroku-buildpack-emberjs) includes `static` buildpack in my setup I'm running this buildpack twice.

#### Expected behaviour:
`nginx.conf.erb` from latter version of `heroku-buildpack-static` overrides former one, w/o affecting binaries.

#### Actual behaviour
two different `nginx.conf.erb` is created:
`~/bin/config/templates/nginx.conf.erb`
`~/bin/config/config/templates/nginx.conf.erb`


I have explanation why that is happening in commit message.