### PR TITLE
Allow FORCE_HTTPS to be specified as an environment variable

### DIFF
--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -44,7 +44,7 @@ class NginxConfig
 
     json["clean_urls"] ||= DEFAULT[:clean_urls]
     json["https_only"] ||= DEFAULT[:https_only]
-    json["https_only"] ||= ENV["FORCE_HTTPS"].present? && ENV["FORCE_HTTPS"] === "true"
+    json["https_only"] ||= !ENV["FORCE_HTTPS"].nil? && ENV["FORCE_HTTPS"] === "true"
 
     json["routes"] ||= {}
     json["routes"] = NginxConfigUtil.parse_routes(json["routes"])

--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -44,6 +44,7 @@ class NginxConfig
 
     json["clean_urls"] ||= DEFAULT[:clean_urls]
     json["https_only"] ||= DEFAULT[:https_only]
+    json["https_only"] ||= ENV["FORCE_HTTPS"].present? && ENV["FORCE_HTTPS"] === "true"
 
     json["routes"] ||= {}
     json["routes"] = NginxConfigUtil.parse_routes(json["routes"])


### PR DESCRIPTION
This allows to specify `FORCE_HTTPS` as a config environment variable similar to what you could do in this buildpack https://github.com/tonycoco/heroku-buildpack-ember-cli/blob/e4aed2b98bde656c6921120fb87ec53040195590/config/nginx.conf.erb#L60. 