### PR TITLE
Remove special handling of html suffix fallback

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -60,12 +60,6 @@ http {
     <% end %>
     }
 
-  <% if clean_urls %>
-    location ~ \.html$ {
-      try_files $uri =404;
-    }
-  <% end %>
-
   <% if https_only %>
     if ($http_x_forwarded_proto != "https") {
       return 301 https://$host$request_uri;


### PR DESCRIPTION
I'm not entirely sure why this clean_urls block for incoming `.html` urls is here (though admittedly I'm not nginx expert). I believe the special handling in the `Location /` block should be adequate and allow for additional fallbacks like redirects and proxies. 

As written in master, if `clean_urls` are enabled and an incoming url ends in `.html` it cannot be redirected. This is a significant problem for SEO if rebuilding or replacing a site.