### PR TITLE
Update mime types adding WebAssembly (wasm)

### DIFF
--- a/scripts/config/templates/mime.types
+++ b/scripts/config/templates/mime.types
@@ -35,6 +35,7 @@ types {
     application/vnd.wap.wmlc              wmlc;
     application/vnd.google-earth.kml+xml  kml;
     application/vnd.google-earth.kmz      kmz;
+    application/wasm                      wasm;
     application/x-7z-compressed           7z;
     application/x-cocoa                   cco;
     application/x-java-archive-diff       jardiff;


### PR DESCRIPTION
Applications written in WebAssembly fail when trying to fetch compiled `.wasm`-files from the server if the content-type is not set to `application/wasm` (see https://github.com/WebAssembly/design/blob/e2be77eaac770268a4c22fb09c6f648de7b9b6b8/Web.md for reference)