### PR TITLE
Added request header support to proxy config

### DIFF
--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -39,6 +39,13 @@ class NginxConfig
         json["proxies"][loc]["redirect_#{scheme}"] = uri.dup.tap {|u| u.scheme = scheme }.to_s
         json["proxies"][loc]["redirect_#{scheme}"] += "/" if !uri.to_s.end_with?("/")
       end
+
+      json["proxies"][loc]["headers"] ||= {}
+      json["proxies"][loc]["headers"].each do |key, value|
+        evaled_value = NginxConfigUtil.interpolate(value, ENV)
+        json["proxies"][loc]["headers"][key] = evaled_value
+      end
+
       index += 1
     end
 

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -101,6 +101,9 @@ http {
       <% %w(http https).each do |scheme| %>
       proxy_redirect <%= hash["redirect_#{scheme}"] %> <%= location %>;
       <% end %>
+      <% hash['headers'].each do |key, value| %>
+      proxy_set_header <%= key %> "<%= value %>";
+      <% end %>
     }
   <% end %>
 


### PR DESCRIPTION
Here's my reasoning for adding header on server side: I'm using proxy to call API that doesn't support CORS. It's an OAuth API and I need to pass app secret to it. I don't want to expose the app secret in JavaScript, so I have to keep it on the server side. I want to store the app secret in an environment variable, reference it through `static.json` and compile it into the Nginx config.