### PR TITLE
Fix starting message leading to confusion in local execution

### DIFF
--- a/scripts/boot
+++ b/scripts/boot
@@ -89,6 +89,9 @@ echo "Starting nginx..." >&2
     wait
 ) & pids+=($!)
 
+# on Heroku, there is a "state changed from starting to up", but for local execution, we want a "ready" message
+[[ -z ${DYNO:-} || $verbose ]] && echo "Application ready for connections on port $PORT." >&2
+
 # wait for something to come from the FIFO attached to FD 3, which means that
 # the given process was killed or has failed this will be interrupted by a
 # SIGTERM or SIGINT in the traps further up if the pipe unblocks and this


### PR DESCRIPTION
I am using the buildpack locally and everything works fine, but I feel that the message "Starting ... " is a bit confusing, so would it be better if it follows (https://github.com/heroku/heroku-buildpack-php/blob/a380d44126a056cc5b7daaa0714714e3c888689f/bin/heroku-hhvm-nginx#L366) 