### PR TITLE
Fix Dockerfile to point to correct repo

### DIFF
--- a/spec/support/docker/router/Dockerfile
+++ b/spec/support/docker/router/Dockerfile
@@ -1,4 +1,4 @@
-FROM matsumotory/ngx-mruby:latest
+FROM matsumotory/ngx_mruby:master
 
 RUN echo $'\nUS\nTexas\nAustin\nHeroku\n\nexample.com\n\n' \
   | openssl req -x509 -nodes -days 365 -newkey rsa:1024 \


### PR DESCRIPTION
This fixes issue whereby all Circle CI builds are currently failing because `matsumotory/ngx-mruby:latest` has moved to `matsumotory/ngx_mruby:master`.

We fix the issue by correcting `FROM` value in the `Dockerfile` for the router.