### PR TITLE
Add support for canonical host

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ This allows you to specify a different asset root for the directory of your appl
 
 By default this is set to `public_html/`
 
+#### Canonical Host
+This allows you to perform 301 redirects to a specific hostname, which can be useful for redirecting www to non-www (or vice versa).
+
+```json
+{
+  "canonical_host": "www.example.com"
+}
+```
+
+You can use environment variables as well:
+
+```json
+{
+  "canonical_host": "${HOST}"
+}
+```
+
 #### Default Character Set
 This allows you to specify a character set for your text assets (HTML, Javascript, CSS, and so on). For most apps, this should be the default value of "UTF-8", but you can override it by setting `encoding`:
 

--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -6,6 +6,7 @@ class NginxConfig
   DEFAULT = {
     root: "public_html/",
     encoding: "UTF-8",
+    canonical_host: false,
     clean_urls: false,
     https_only: false,
     basic_auth: false,
@@ -25,6 +26,9 @@ class NginxConfig
     json["port"] ||= ENV["PORT"] || 5000
     json["root"] ||= DEFAULT[:root]
     json["encoding"] ||= DEFAULT[:encoding]
+
+    json["canonical_host"] ||= DEFAULT[:canonical_host]
+    json["canonical_host"] = NginxConfigUtil.interpolate(json["canonical_host"], ENV) if json["canonical_host"]
 
     index = 0
     json["proxies"] ||= {}

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -79,7 +79,7 @@ http {
 
   <% if canonical_host %>
     if ($host != <%= canonical_host %>) {
-      return 301 $scheme://<%= canonical_host %>$request_uri;
+      return 301 $http_x_forwarded_proto://<%= canonical_host %>$request_uri;
     }
   <% end %>
 

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -77,6 +77,12 @@ http {
     }
   <% end %>
 
+  <% if canonical_host %>
+    if ($host != <%= canonical_host %>) {
+      return 301 $scheme://<%= canonical_host %>$request_uri;
+    }
+  <% end %>
+
   <% routes.each do |route, path| %>
     location ~ ^<%= route %>$ {
       set $route <%= route %>;


### PR DESCRIPTION
Add support for canonical host (e.g for SEO purpose)

I was inspired by https://github.com/keepworks/heroku-buildpack-static but simplify the nginx config.

Resolve #60 #110 #135 