### PR TITLE
Don't render canonical host redirect if HEROKU_PARENT_APP_NAME is set

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -77,7 +77,7 @@ http {
     }
   <% end %>
 
-  <% if canonical_host %>
+  <% if canonical_host && !ENV['HEROKU_PARENT_APP_NAME'] %>
     if ($host != <%= canonical_host %>) {
       return 301 $http_x_forwarded_proto://<%= canonical_host %>$request_uri;
     }


### PR DESCRIPTION
This enables the main app to have a canonical domain, but earlier stages 
of the pipeline will use their heroku-given URLs.