### PR TITLE
[changelog skip] Ensure PRs include a Changelog entry

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -1,6 +1,8 @@
 name: Check Changelog
 
-on: [pull_request]
+on:
+ pull_request:
+  types: [opened, reopened, edited, synchronize]
 
 jobs:
  build:

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -1,0 +1,12 @@
+name: Check Changelog
+
+on: [pull_request]
+
+jobs:
+ build:
+   runs-on: ubuntu-latest
+   steps:
+   - uses: actions/checkout@v1
+   - name: Check that CHANGELOG is touched
+     run: |
+       cat $GITHUB_EVENT_PATH | jq .pull_request.title |  grep -i '[((changelog skip)|(ci skip))]' ||  git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md


### PR DESCRIPTION
The goal of this PR is to add a github action that checks for the presence of a changelog entry.

It is better to add entries as a PR is merged instead of having to remember what was merged and generate a changelog at release time.

By automating this check, it's one less thing the maintainer has to remember, and it's one less thing a change might be blocked on i.e. "Looks good, but please add a changelog entry".

Let me know if you have any questions and Happy Friday!