### PR TITLE
Verbose output on missing static.json

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -4,6 +4,7 @@
 build_dir=$1
 
 if [ ! -f "$build_dir/static.json" ]; then
+    echo "file named 'static.json' missing in $build_dir"
     exit 1
 fi
 


### PR DESCRIPTION
Happened to me that I was accidentally starting a project and forgot to commit static.json to the root of the project. This message would have saved some time investigating what was wrong.