### PR TITLE
Buildpack compile fixes and refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Make curl retry in case of a failed download
 * [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Fix the printing of the installed nginx version
 * [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Switch to the recommended S3 URL format
 * [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Remove unused archive caching

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Fix the printing of the installed nginx version
 * [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Switch to the recommended S3 URL format
 * [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Remove unused archive caching
 * [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Fail the build early on unsupported stacks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Remove unused archive caching
 * [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Fail the build early on unsupported stacks
 
 ## v4 (2019-09-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Switch to the recommended S3 URL format
 * [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Remove unused archive caching
 * [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Fail the build early on unsupported stacks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Fail the build early on unsupported stacks
 
 ## v4 (2019-09-18)
 

--- a/bin/compile
+++ b/bin/compile
@@ -10,7 +10,9 @@ bp_dir=$(dirname $(dirname $0))
 
 case "${STACK}" in
   cedar-14|heroku-16|heroku-18)
-    # Supported stack
+    # The buildpack for some time has used binaries meant for Cedar-14 on all stacks (see #165).
+    # In the future these stacks should be migrated to newer nginx built against the correct stack.
+    nginx_archive_url='https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/nginx/cedar-14/nginx-1.9.7-ngx_mruby.tgz'
     ;;
   *)
     echo "Stack ${STACK} is not supported!"
@@ -18,22 +20,8 @@ case "${STACK}" in
     ;;
 esac
 
-fetch_nginx_tarball() {
-    local version="1.9.7"
-    local tarball_file="nginx-$version.tgz"
-    local stack="cedar-14"
-    local nginx_tarball_url="https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/nginx/$stack/nginx-$version-ngx_mruby.tgz"
-    local dest_path="$cache_dir/$stack/$tarball_file"
-
-    if [ -f "$dest_path" ]; then
-        echo -n "cat $dest_path"
-    else
-        echo -n "curl -L $nginx_tarball_url"
-    fi
-}
-
 mkdir -p $build_dir/bin
-$(fetch_nginx_tarball) | tar xzC $build_dir/bin
+curl -sSf "${nginx_archive_url}" | tar -xzC "${build_dir}/bin"
 nginx_version=$($build_dir/bin/nginx-$STACK -V 2>&1 | head -1 | awk '{ print $NF }')
 cp -a $bp_dir/scripts/{boot,config} -t $build_dir/bin/
 echo "-----> Installed ${nginx_version} to /app/bin"

--- a/bin/compile
+++ b/bin/compile
@@ -21,7 +21,7 @@ case "${STACK}" in
 esac
 
 mkdir -p $build_dir/bin
-curl -sSf "${nginx_archive_url}" | tar -xzC "${build_dir}/bin"
+curl -sSf --retry 3 --connect-timeout 3 "${nginx_archive_url}" | tar -xzC "${build_dir}/bin"
 nginx_version=$("${build_dir}/bin/nginx" -v |& cut -d '/' -f 2-)
 cp -a $bp_dir/scripts/{boot,config} -t $build_dir/bin/
 echo "-----> Installed nginx ${nginx_version} to /app/bin"

--- a/bin/compile
+++ b/bin/compile
@@ -32,5 +32,3 @@ mkdir -p $build_dir/config
 cp $bp_dir/scripts/config/templates/mime.types $build_dir/config
 
 mkdir -p $build_dir/logs
-
-exit 0

--- a/bin/compile
+++ b/bin/compile
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # bin/compile <build-dir> <cache-dir> <env-dir>
 
-set -e
+set -euo pipefail
 
 build_dir=$1
 cache_dir=$2

--- a/bin/compile
+++ b/bin/compile
@@ -22,9 +22,9 @@ esac
 
 mkdir -p $build_dir/bin
 curl -sSf "${nginx_archive_url}" | tar -xzC "${build_dir}/bin"
-nginx_version=$($build_dir/bin/nginx-$STACK -V 2>&1 | head -1 | awk '{ print $NF }')
+nginx_version=$("${build_dir}/bin/nginx" -v |& cut -d '/' -f 2-)
 cp -a $bp_dir/scripts/{boot,config} -t $build_dir/bin/
-echo "-----> Installed ${nginx_version} to /app/bin"
+echo "-----> Installed nginx ${nginx_version} to /app/bin"
 
 mkdir -p $build_dir/config
 cp $bp_dir/scripts/config/templates/mime.types $build_dir/config

--- a/bin/compile
+++ b/bin/compile
@@ -12,7 +12,7 @@ case "${STACK}" in
   cedar-14|heroku-16|heroku-18)
     # The buildpack for some time has used binaries meant for Cedar-14 on all stacks (see #165).
     # In the future these stacks should be migrated to newer nginx built against the correct stack.
-    nginx_archive_url='https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/nginx/cedar-14/nginx-1.9.7-ngx_mruby.tgz'
+    nginx_archive_url='https://heroku-buildpack-ruby.s3.amazonaws.com/nginx/cedar-14/nginx-1.9.7-ngx_mruby.tgz'
     ;;
   *)
     echo "Stack ${STACK} is not supported!"

--- a/bin/compile
+++ b/bin/compile
@@ -8,6 +8,16 @@ cache_dir=$2
 env_dir=$3
 bp_dir=$(dirname $(dirname $0))
 
+case "${STACK}" in
+  cedar-14|heroku-16|heroku-18)
+    # Supported stack
+    ;;
+  *)
+    echo "Stack ${STACK} is not supported!"
+    exit 1
+    ;;
+esac
+
 fetch_nginx_tarball() {
     local version="1.9.7"
     local tarball_file="nginx-$version.tgz"


### PR DESCRIPTION
In order to reduce the size of the Heroku-20 support PR, I've split out some of the compile fixes/cleanup.

The most notable of these are:
- The build now fails early for unsupported stacks, rather than appearing to succeed only for the app to fail at runtime (as seen in #166)
- The printing of the nginx version is now fixed (#174)

See the individual commit messages (and changelog entries) for more details.

Refs [W-8367040](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008VTdWIAW/view).