### PR TITLE
Exclude unnecessary files when publishing the buildpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#178](https://github.com/heroku/heroku-buildpack-static/pull/178) Exclude unnecessary files when publishing the buildpack
 * [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Make curl retry in case of a failed download
 * [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Fix the printing of the installed nginx version
 * [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Switch to the recommended S3 URL format

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,0 +1,15 @@
+[buildpack]
+name = "Static HTML"
+
+  [publish.Ignore]
+  files = [
+    ".github/",
+    "spec/",
+    ".gitignore",
+    ".rspec",
+    "circle.yml",
+    "Gemfile",
+    "Gemfile.lock",
+    "Makefile",
+    "Rakefile"
+  ]


### PR DESCRIPTION
Since currently the archive on the buildpack registry contains a lot more than the ~15 files needed at compile time:

```
$ curl -sSf https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku-community/static.tgz | tar -zt | wc -l
234
```

See:
https://devcenter.heroku.com/articles/buildpack-registry#creating-a-buildpack-descriptor

Refs [W-8367040](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008VTdWIAW/view).