### PR TITLE
Fix compatibility with ngx_mruby 1.18.4+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#181](https://github.com/heroku/heroku-buildpack-static/pull/181) Fix compatibility with ngx_mruby 1.18.4+
 * [#178](https://github.com/heroku/heroku-buildpack-static/pull/178) Exclude unnecessary files when publishing the buildpack
 * [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Make curl retry in case of a failed download
 * [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Fix the printing of the installed nginx version

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -55,8 +55,9 @@ http {
     auth_basic_user_file <%= basic_auth_htpasswd_path %>;
   <% end %>
 
+    mruby_post_read_handler /app/bin/config/lib/ngx_mruby/headers.rb cache;
+
     location / {
-      mruby_post_read_handler /app/bin/config/lib/ngx_mruby/headers.rb cache;
       mruby_set $fallback /app/bin/config/lib/ngx_mruby/routes_fallback.rb cache;
     <% if clean_urls %>
       try_files $uri.html $uri $uri/ $fallback;


### PR DESCRIPTION
The `mruby_post_read_handler` directive should always have been outside the `location` block, however due to a bug in ngx_mruby the previous implementation happened to still work.

In ngx_mruby 1.18.4 this silently stopped being the case:
https://github.com/matsumotory/ngx_mruby/issues/210

And in ngx_mruby 1.18.5 this incorrect usage was turned into an error:
https://github.com/matsumotory/ngx_mruby/pull/217

Moving `mruby_post_read_handler` outside the location block is a no-op for the older ngx_mruby currently used by this buildpack, but ensures compatibility with the newer ngx_mruby being used in the upcoming Heroku-20 support PR.

See matsumotory/ngx_mruby#210.

Refs [W-8367040](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008VTdWIAW/view).