### PR TITLE
Add support for Heroku-20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+archives/
 vendor/
 .bundle/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#182](https://github.com/heroku/heroku-buildpack-static/pull/182) Add support for Heroku-20
 * [#181](https://github.com/heroku/heroku-buildpack-static/pull/181) Fix compatibility with ngx_mruby 1.18.4+
 * [#178](https://github.com/heroku/heroku-buildpack-static/pull/178) Exclude unnecessary files when publishing the buildpack
 * [#177](https://github.com/heroku/heroku-buildpack-static/pull/177) Make curl retry in case of a failed download

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+S3_BUCKET ?= heroku-buildpack-static
+
+.PHONY: build build-heroku-16 build-heroku-18 build-heroku-20 sync
+
+build: build-heroku-16 build-heroku-18 build-heroku-20
+
+build-heroku-16:
+	@docker pull heroku/heroku:16-build
+	@docker run -v "$(shell pwd)":/buildpack --rm -it -e "STACK=heroku-16" heroku/heroku:16-build /buildpack/scripts/build_ngx_mruby.sh
+
+build-heroku-18:
+	@docker pull heroku/heroku:18-build
+	@docker run -v "$(shell pwd)":/buildpack --rm -it -e "STACK=heroku-18" heroku/heroku:18-build /buildpack/scripts/build_ngx_mruby.sh
+
+build-heroku-20:
+	@docker pull heroku/heroku:20-build
+	@docker run -v "$(shell pwd)":/buildpack --rm -it -e "STACK=heroku-20" heroku/heroku:20-build /buildpack/scripts/build_ngx_mruby.sh
+
+sync:
+	@echo "Performing dry run of sync to $(S3_BUCKET)..."
+	@echo
+	@aws s3 sync archives/ s3://$(S3_BUCKET) --dryrun
+	@echo
+	@read -p "Continue with sync? [y/N]? " answer && [ "$$answer" = "y" ]
+	@echo
+	@aws s3 sync archives/ s3://$(S3_BUCKET)

--- a/README.md
+++ b/README.md
@@ -303,3 +303,17 @@ You need to forward the docker's port 3000 to the virtual machine's port though.
 ```
 VBoxManage modifyvm "boot2docker-vm" --natpf1 "tcp-port3000,tcp,,3000,,3000";
 ```
+
+## Releasing new binaries
+
+The steps buildpack maintainers need to perform when releasing new nginx
+binaries (either for a new stack or `ngx_mruby` version), are:
+
+1. Update the stacks list in `Makefile` and/or the ngx_mruby version
+  in `scripts/build_ngx_mruby.sh`.
+2. Run `make build` to build all stacks or `make build-heroku-NN` to build just one stack.
+3. Ensure the AWS CLI is installed (eg `brew install awscli`).
+4. Authenticate with the relevant AWS account (typically by setting the environment variables from PCSK).
+5. Run `make sync` (or if using a custom S3 bucket, `S3_BUCKET=... make sync`).
+6. Update `bin/compile` to reference the new stacks and/or nginx version URLs.
+7. Open a PR with the changes from (1) and (6).

--- a/bin/compile
+++ b/bin/compile
@@ -9,6 +9,9 @@ env_dir=$3
 bp_dir=$(dirname $(dirname $0))
 
 case "${STACK}" in
+  heroku-20)
+    nginx_archive_url="https://heroku-buildpack-static.s3.amazonaws.com/${STACK}/nginx-1.19.0-ngx_mruby-2.2.3.tgz"
+    ;;
   cedar-14|heroku-16|heroku-18)
     # The buildpack for some time has used binaries meant for Cedar-14 on all stacks (see #165).
     # In the future these stacks should be migrated to newer nginx built against the correct stack.

--- a/scripts/build_ngx_mruby.sh
+++ b/scripts/build_ngx_mruby.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NGX_MRUBY_VERSION='2.2.3'
+NGX_MRUBY_URL="https://github.com/matsumotory/ngx_mruby/archive/v${NGX_MRUBY_VERSION}.tar.gz"
+
+echo "Building ngx_mruby v${NGX_MRUBY_VERSION} for ${STACK}"
+
+BUILD_DIR=$(mktemp -d /tmp/ngx_mruby.XXXX)
+SCRIPTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+OUTPUT_DIR="$(dirname "${SCRIPTS_DIR}")/archives/${STACK}"
+
+mkdir -p "${OUTPUT_DIR}"
+cd "${BUILD_DIR}"
+
+echo "Downloading ngx_mruby from ${NGX_MRUBY_URL}"
+curl -sSfL "${NGX_MRUBY_URL}" | tar -xz --strip-components 1
+
+./build.sh
+make install
+
+echo 'nginx build complete!'
+
+NGINX_BIN_DIR="${BUILD_DIR}/build/nginx/sbin"
+cd "${NGINX_BIN_DIR}"
+
+# Check that nginx can start
+./nginx -v
+
+NGINX_VERSION=$(./nginx -v |& cut -d '/' -f 2-)
+ARCHIVE_PATH="${OUTPUT_DIR}/nginx-${NGINX_VERSION}-ngx_mruby-${NGX_MRUBY_VERSION}.tgz"
+
+tar -czf "${ARCHIVE_PATH}" nginx
+
+echo "Archive saved to: ${ARCHIVE_PATH}"


### PR DESCRIPTION
This adds support for the new Heroku-20 stack:
https://devcenter.heroku.com/articles/heroku-20-stack

The buildpack's binaries were previously generated by:
https://github.com/hone/docker-nginx-builder

However that repository is quite out of date, and much of its complexity is no longer required thanks to improvements to `ngx_mruby`'s upstream build scripts/process:
https://github.com/matsumotory/ngx_mruby/tree/v2.2.3/docs/install
https://github.com/matsumotory/ngx_mruby/blob/v2.2.3/build.sh

The new build script has been co-located in this buildpack to improve discoverability, and prevent needing to open PRs against multiple repos when performing updates.

The buildpack previously used a subdirectory of the Ruby buildpack's S3 bucket, however I've created a new S3 bucket to improve isolation.

This PR adds support for building new binaries for all stacks, however for now only switches to them for Heroku-20, so that the newer nginx version can be tested on the new stack for a while before backporting to the others.

The newer ngx_mruby required a compatibility fix, however that has already landed in #181.

The binaries have been uploaded already, using the newly documented steps in the README.

Closes #166.
Closes [W-8367040](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008VTdWIAW/view).