### PR TITLE
Ensure the SSL module is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#186](https://github.com/heroku/heroku-buildpack-static/pull/186) Ensure the SSL module is enabled
 
 ## v5 (2020-11-11)
 

--- a/scripts/build_ngx_mruby.sh
+++ b/scripts/build_ngx_mruby.sh
@@ -17,7 +17,14 @@ cd "${BUILD_DIR}"
 echo "Downloading ngx_mruby from ${NGX_MRUBY_URL}"
 curl -sSfL "${NGX_MRUBY_URL}" | tar -xz --strip-components 1
 
-./build.sh
+# Taken from the defaults:
+# https://github.com/matsumotory/ngx_mruby/blob/v2.2.3/build.sh#L23-L40
+BUILD_OPTS="--prefix=${PWD}/build/nginx"
+BUILD_OPTS+=' --with-http_stub_status_module --with-stream --without-stream_access_module --with-cc-opt=-fno-common'
+# Our custom addition, to enable the SSL module.
+BUILD_OPTS+=' --with-http_ssl_module'
+
+NGINX_CONFIG_OPT_ENV="${BUILD_OPTS}" ./build.sh
 make install
 
 echo 'nginx build complete!'
@@ -26,7 +33,10 @@ NGINX_BIN_DIR="${BUILD_DIR}/build/nginx/sbin"
 cd "${NGINX_BIN_DIR}"
 
 # Check that nginx can start
-./nginx -v
+./nginx -V
+
+# Check that OpenSSL support was enabled
+./nginx -V |& grep 'built with OpenSSL' || { echo 'Missing OpenSSL support!'; exit 1; }
 
 NGINX_VERSION=$(./nginx -v |& cut -d '/' -f 2-)
 ARCHIVE_PATH="${OUTPUT_DIR}/nginx-${NGINX_VERSION}-ngx_mruby-${NGX_MRUBY_VERSION}.tgz"


### PR DESCRIPTION
Previously the compile silently skipped the SSL module:

```
Configuration summary
  ...
  + OpenSSL library is not used
```

Which causes failures if SSL related directives are used.

Now the `--with-http_ssl_module` flag is passed, which results in:

```
Configuration summary
  ...
  + using system OpenSSL library
```

And `nginx -V` now includes an additional line:

```
built with OpenSSL 1.1.1f  31 Mar 2020
```

See:
https://github.com/matsumotory/ngx_mruby/tree/master/docs/install#3-a-using-buildsh

Fixes #185.
Closes [W-8449334](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008jEO5IAM/view).