### PR TITLE
Update nginx for Heroku-16 and Heroku-18 to 1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#190](https://github.com/heroku/heroku-buildpack-static/pull/190) Update nginx for Heroku-16 and Heroku-18 to 1.19.0
 * [#186](https://github.com/heroku/heroku-buildpack-static/pull/186) Ensure the SSL module is enabled
 
 ## v5 (2020-11-11)

--- a/bin/compile
+++ b/bin/compile
@@ -9,12 +9,10 @@ env_dir=$3
 bp_dir=$(dirname $(dirname $0))
 
 case "${STACK}" in
-  heroku-20)
+  heroku-16|heroku-18|heroku-20)
     nginx_archive_url="https://heroku-buildpack-static.s3.amazonaws.com/${STACK}/nginx-1.19.0-ngx_mruby-2.2.3.tgz"
     ;;
-  cedar-14|heroku-16|heroku-18)
-    # The buildpack for some time has used binaries meant for Cedar-14 on all stacks (see #165).
-    # In the future these stacks should be migrated to newer nginx built against the correct stack.
+  cedar-14)
     nginx_archive_url='https://heroku-buildpack-ruby.s3.amazonaws.com/nginx/cedar-14/nginx-1.9.7-ngx_mruby.tgz'
     ;;
   *)


### PR DESCRIPTION
Upgrades nginx from 1.9.7 to 1.19.0, to match that already used for Heroku-20. 

In addition, the buildpack now uses the correct binaries for these stacks, rather than using a binary compiled for Cedar-14.

The binaries were previously uploaded in https://github.com/heroku/heroku-buildpack-static/pull/186#issuecomment-730656605.

Fixes #165.