### PR TITLE
Docs: Use the buildpack registry URL in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For a guide, read the [Getting Started with Single Page Apps on Heroku](https://
 ## Deploying
 The `static.json` file is required to use this buildpack. This file handles all the configuration described below.
 
-1. Set the app to this buildpack: `$ heroku buildpacks:set https://github.com/heroku/heroku-buildpack-static.git`.
+1. Set the app to this buildpack: `$ heroku buildpacks:set heroku-community/static`.
 2. Deploy: `$ git push heroku master`
 
 ### Configuration


### PR DESCRIPTION
Since this buildpack exists on the buildpack registry under the name `heroku-community/static`, and using buildpack registry versions is recommended over the GitHub URLs.