### PR TITLE
adds interpolation for root

### DIFF
--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -24,8 +24,10 @@ class NginxConfig
     json = JSON.parse(File.read(json_file)) if File.exist?(json_file)
     json["worker_connections"] ||= ENV["WORKER_CONNECTIONS"] || DEFAULT[:worker_connections]
     json["port"] ||= ENV["PORT"] || 5000
-    json["root"] ||= DEFAULT[:root]
     json["encoding"] ||= DEFAULT[:encoding]
+    
+    json["root"] ||= DEFAULT[:root]
+    json["root"] = NginxConfigUtil.interpolate(json["root"], ENV) if json["root"]
 
     json["canonical_host"] ||= DEFAULT[:canonical_host]
     json["canonical_host"] = NginxConfigUtil.interpolate(json["canonical_host"], ENV) if json["canonical_host"]


### PR DESCRIPTION
Allows root config to be interpolated with env variables, this will help static sites built in a monorepo to use a single static.json and change the root using env variables