### PR TITLE
Output a helpful error message when no static.json is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#202](https://github.com/heroku/heroku-buildpack-static/pull/202) Output a helpful error message when no `static.json` is found
 
 ## v6 (2020-12-09)
 

--- a/bin/detect
+++ b/bin/detect
@@ -4,6 +4,7 @@
 build_dir=$1
 
 if [ ! -f "$build_dir/static.json" ]; then
+    echo "Could not find 'static.json'! Please ensure it exists and is checked into Git." >&2
     exit 1
 fi
 


### PR DESCRIPTION
The error message is now output to `stderr` otherwise it's not shown.

Closes GUS-W-8799430.
Refs #198.