### PR TITLE
README: Fix spelling of 'instead'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The `static.json` file is required to use this buildpack. This file handles all 
 You can configure different options for your static application by writing a `static.json` in the root folder of your application.
 
 #### Root
-This allows you to specify a different asset root for the directory of your application. For instance, if you're using ember-cli, it naturally builds a `dist/` directory, so you might want to use that intsead.
+This allows you to specify a different asset root for the directory of your application. For instance, if you're using ember-cli, it naturally builds a `dist/` directory, so you might want to use that instead.
 
 ```json
 {


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/heroku-buildpack-static/commit/011cf1cff147b5d0ae17414af6261f9bf4aacf0c#commitcomment-51258705

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/heroku-buildpack-static/commit/ce915a4cea53f3a46b930ac8117089645c9b280a