### PR TITLE
Adds support for client_max_body_size for static.json config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # heroku-buildpack-static
+
 **NOTE**: This buildpack is in an experimental OSS project.
 
 This is a buildpack for handling static sites and single page web apps.
@@ -6,33 +7,37 @@ This is a buildpack for handling static sites and single page web apps.
 For a guide, read the [Getting Started with Single Page Apps on Heroku](https://gist.github.com/hone/24b06869b4c1eca701f9).
 
 ## Features
-* serving static assets
-* gzip on by default
-* error/access logs support in `heroku logs`
-* custom [configuration](#configuration)
+
+- serving static assets
+- gzip on by default
+- error/access logs support in `heroku logs`
+- custom [configuration](#configuration)
 
 ## Deploying
+
 The `static.json` file is required to use this buildpack. This file handles all the configuration described below.
 
 1. Set the app to this buildpack: `$ heroku buildpacks:set heroku-community/static`.
 2. Deploy: `$ git push heroku master`
 
 ### Configuration
+
 You can configure different options for your static application by writing a `static.json` in the root folder of your application.
 
 #### Root
+
 This allows you to specify a different asset root for the directory of your application. For instance, if you're using ember-cli, it naturally builds a `dist/` directory, so you might want to use that instead.
 
 ```json
 {
   "root": "dist/"
 }
-
 ```
 
 By default this is set to `public_html/`
 
 #### Canonical Host
+
 This allows you to perform 301 redirects to a specific hostname, which can be useful for redirecting www to non-www (or vice versa).
 
 ```json
@@ -50,17 +55,32 @@ You can use environment variables as well:
 ```
 
 #### Default Character Set
+
 This allows you to specify a character set for your text assets (HTML, Javascript, CSS, and so on). For most apps, this should be the default value of "UTF-8", but you can override it by setting `encoding`:
 
 ```json
 {
-    "encoding": "US-ASCII"
+  "encoding": "US-ASCII"
 }
 ```
 
-#### Clean URLs
-For SEO purposes, you can drop the `.html` extension from URLs for say a blog site. This means users could go to `/foo` instead of `/foo.html`.
+#### NGINX Configuration
 
+### Client Max Body Size
+
+By default, nginx has a default max body size of 1 megabyte. Any request above this size (e.g. uploading a 2m file) will result in a `413 Request Entity too Large` error. You can configure this value by setting `max_body_size:`
+
+```json
+{
+  "max_body_size": "10m"
+}
+```
+
+The size setting follows nginx's convention of bytes, kilobytes and megabytes (1024, 8k, 1m).
+
+#### Clean URLs
+
+For SEO purposes, you can drop the `.html` extension from URLs for say a blog site. This means users could go to `/foo` instead of `/foo.html`.
 
 ```json
 {
@@ -70,8 +90,8 @@ For SEO purposes, you can drop the `.html` extension from URLs for say a blog si
 
 By default this is set to `false`.
 
-
 #### Logging
+
 You can disable the access log and change the severity level for the error log.
 
 ```json
@@ -87,12 +107,12 @@ By default `access` is set to `true` and `error` is set to `error`.
 
 The environment variable `STATIC_DEBUG` can be set, to override the `error` log level to `error`.
 
-
 #### Custom Routes
+
 You can define custom routes that combine to a single file. This allows you to preserve routing for a single page web application. The following operators are supported:
 
-* `*` supports a single path segment in the URL. In the configuration below, `/baz.html` would match but `/bar/baz.html` would not.
-* `**` supports any length in the URL.  In the configuration below, both `/route/foo` would work and `/route/foo/bar/baz`.
+- `*` supports a single path segment in the URL. In the configuration below, `/baz.html` would match but `/bar/baz.html` would not.
+- `**` supports any length in the URL. In the configuration below, both `/route/foo` would work and `/route/foo/bar/baz`.
 
 ```json
 {
@@ -104,6 +124,7 @@ You can define custom routes that combine to a single file. This allows you to p
 ```
 
 ##### Browser history and asset files
+
 When serving a single page app, it's useful to support wildcard URLs that serves the index.html file, while also continuing to serve JS and CSS files correctly. Route ordering allows you to do both:
 
 ```json
@@ -116,6 +137,7 @@ When serving a single page app, it's useful to support wildcard URLs that serves
 ```
 
 #### Custom Redirects
+
 With custom redirects, you can move pages to new routes but still preserve the old routes for SEO purposes. By default, we return a `301` status code, but you can specify the status code you want.
 
 ```json
@@ -130,6 +152,7 @@ With custom redirects, you can move pages to new routes but still preserve the o
 ```
 
 ##### Interpolating Env Var Values
+
 It's common to want to be able to test the frontend against various backends. The `url` key supports environment variable substitution using `${ENV_VAR_NAME}`. For instance, if there was a staging and production Heroku app for your API, you could setup the config above like the following:
 
 ```json
@@ -149,6 +172,7 @@ $ heroku config:set NEW_SITE_DOMAIN="https://example.herokapp.com"
 ```
 
 #### Custom Error Pages
+
 You can replace the default nginx 404 and 500 error pages by defining the path to one in your config.
 
 ```json
@@ -182,6 +206,7 @@ This will generate `.htpasswd` using environment variables `BASIC_AUTH_USERNAME`
 Passwords set via `BASIC_AUTH_PASSWORD` can be generated using OpenSSL or Apache Utils. For instance: `openssl passwd -apr1`.
 
 #### Proxy Backends
+
 For single page web applications like Ember, it's common to back the application with another app that's hosted on Heroku. The down side of separating out these two applications is that now you have to deal with CORS. To get around this (but at the cost of some latency) you can have the static buildpack proxy apps to your backend at a mountpoint. For instance, we can have all the api requests live at `/api/` which actually are just requests to our API server.
 
 ```json
@@ -195,6 +220,7 @@ For single page web applications like Ember, it's common to back the application
 ```
 
 ##### Interpolating Env Var Values
+
 It's common to want to be able to test the frontend against various backends. The `origin` key supports environment variable substitution using `${ENV_VAR_NAME}`. For instance, if there was a staging and production Heroku app for your API, you could setup the config above like the following:
 
 ```json
@@ -214,6 +240,7 @@ $ heroku config:set API_APP_NAME="hone-ember-todo-rails"
 ```
 
 #### Custom Headers
+
 Using the headers key, you can set custom response headers. It uses the same operators for pathing as [Custom Routes](#custom-routes).
 
 ```json
@@ -245,6 +272,7 @@ For example, to enable CORS for all resources, you just need to enable it for al
 ```
 
 ##### Precedence
+
 When there are header conflicts, the last header definition always wins. The headers do not get appended. For example,
 
 ```json
@@ -265,19 +293,20 @@ when accessing `/foo`, `X-Foo` will have the value `"foo"` and `X-Bar` will not 
 
 ### Route Ordering
 
-* HTTPS redirect
-* Root Files
-* Clean URLs
-* Proxies
-* Redirects
-* Custom Routes
-* 404
+- HTTPS redirect
+- Root Files
+- Clean URLs
+- Proxies
+- Redirects
+- Custom Routes
+- 404
 
 ### Procfile / multiple buildpacks
 
 In case you have multiple buildpacks for the application you can ensure static rendering in `Procfile` with `web: bin/boot`.
 
 ## Testing
+
 For testing we use Docker to replicate Heroku locally. You'll need to have [it setup locally](https://docs.docker.com/installation/). We're also using rspec for testing with Ruby. You'll need to have those setup and install those deps:
 
 ```sh
@@ -291,6 +320,7 @@ $ bundle exec rspec
 ```
 
 ### Structure
+
 To add a new test, add another example inside `spec/simple_spec.rb` or create a new file based off of `spec/simple_spec.rb`. All the example apps live in `spec/fixtures`.
 
 When writing a test, `BuildpackBuilder` creates the docker container we need that represents the heroku cedar-14 stack. `AppRunner.new` takes the name of a fixture and mounts it in the container built by `BuildpackBuilder` to run tests against. The `AppRunner` instance provides convenience methods like `get` that just wrap `net/http` for analyzing the response.
@@ -310,7 +340,7 @@ The steps buildpack maintainers need to perform when releasing new nginx
 binaries (either for a new stack or `ngx_mruby` version), are:
 
 1. Update the stacks list in `Makefile` and/or the ngx_mruby version
-  in `scripts/build_ngx_mruby.sh`.
+   in `scripts/build_ngx_mruby.sh`.
 2. Run `make build` to build all stacks or `make build-heroku-NN` to build just one stack.
 3. Ensure the AWS CLI is installed (eg `brew install awscli`).
 4. Authenticate with the relevant AWS account (typically by setting the environment variables from PCSK).

--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -9,6 +9,7 @@ class NginxConfig
     canonical_host: false,
     clean_urls: false,
     https_only: false,
+    max_body_size: "1M",
     basic_auth: false,
     basic_auth_htpasswd_path: "/app/.htpasswd",
     worker_connections: 512,
@@ -50,6 +51,7 @@ class NginxConfig
 
     json["clean_urls"] ||= DEFAULT[:clean_urls]
     json["https_only"] ||= DEFAULT[:https_only]
+    json["max_body_size"] ||= DEFAULT[:max_body_size]
 
     json["basic_auth"] = true unless ENV['BASIC_AUTH_USERNAME'].nil?
     json["basic_auth"] ||= DEFAULT[:basic_auth]

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -43,6 +43,7 @@ http {
     port_in_redirect off;
     keepalive_timeout 5;
     root <%= root %>;
+    client_max_body_size <%= max_body_size %>;
   <% if error_page %>
     error_page 404 500 /<%= error_page %>;
   <% end %>


### PR DESCRIPTION
This a clone of another PR here, which has been approved: https://github.com/heroku/heroku-buildpack-static/pull/42

The change adds support for `client_max_body_size` to the Nginx configs.

The original PR has been sitting around for a few years, and the author hasn't rebased in master. Since it's gone quiet, I've created a clone of that PR in hopes of getting the change merged in. 🙏 

_For now my org is using a fork with these changes, but it would be nice to move back to the original version._