### PR TITLE
Add wasm mimetype

### DIFF
--- a/scripts/config/templates/mime.types
+++ b/scripts/config/templates/mime.types
@@ -35,6 +35,7 @@ types {
     application/vnd.wap.wmlc              wmlc;
     application/vnd.google-earth.kml+xml  kml;
     application/vnd.google-earth.kmz      kmz;
+    application/wasm                      wasm;
     application/x-7z-compressed           7z;
     application/x-cocoa                   cco;
     application/x-java-archive-diff       jardiff;


### PR DESCRIPTION
Proper Content-Type for web assembly files speeds up compilation process and reduces startup time