### PR TITLE
Use the right MIME type for JavaScript files

### DIFF
--- a/scripts/config/templates/mime.types
+++ b/scripts/config/templates/mime.types
@@ -1,11 +1,11 @@
 types {
     text/html                             html htm shtml;
     text/css                              css;
+    text/javascript                       js;
     text/xml                              xml;
     text/cache-manifest                   manifest appcache;
     image/gif                             gif;
     image/jpeg                            jpeg jpg;
-    application/x-javascript              js;
     application/atom+xml                  atom;
     application/rss+xml                   rss;
 


### PR DESCRIPTION
The `mime.types` config uses an outdated MIME type for `.js` files (`application/x-javascript`). As [MDN states](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#textjavascript) (emphasis mine):

> Per the HTML specification, JavaScript files should always be served using the MIME type `text/javascript`. **No other values are considered valid, and using any of those may result in scripts that do not load or run**.