### PR TITLE
Port Check Changelog improvements from other repos

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -1,13 +1,24 @@
 name: Check Changelog
 
 on:
- pull_request:
-  types: [opened, reopened, edited, synchronize]
+  pull_request:
+    types: [opened, reopened, edited, labeled, unlabeled, synchronize]
+
+permissions:
+  contents: read
+
 jobs:
- build:
-   runs-on: ubuntu-latest
-   steps:
-   - uses: actions/checkout@v1
-   - name: Check that CHANGELOG is touched
-     run: |
-       cat $GITHUB_EVENT_PATH | jq .pull_request.title |  grep -i '\[\(\(changelog skip\)\|\(ci skip\)\)\]' ||  git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md
+  check-changelog:
+    runs-on: ubuntu-latest
+    if: |
+      !contains(github.event.pull_request.body, '[skip changelog]') &&
+      !contains(github.event.pull_request.body, '[changelog skip]') &&
+      !contains(github.event.pull_request.body, '[skip ci]') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip changelog') &&
+      !contains(github.event.pull_request.labels.*.name, 'dependencies')
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check that CHANGELOG is touched
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth 1 && \
+          git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md


### PR DESCRIPTION
eg:
https://github.com/heroku/heroku-buildpack-python/blob/5d6776f77a89e7ef3ada701d05c473117ecf817a/.github/workflows/check_changelog.yml

Notably, one can now use both a label and a PR description attribute, rather than the unsightly PR title annotation.