### PR TITLE
Drop support for Cedar-14 and Heroku-16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [#238](https://github.com/heroku/heroku-buildpack-static/pull/238) Drop support for Cedar-14 and Heroku-16.
 
 ## v7 (2021-03-09)
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,8 @@
 S3_BUCKET ?= heroku-buildpack-static
 
-.PHONY: build build-heroku-16 build-heroku-18 build-heroku-20 sync
+.PHONY: build build-heroku-18 build-heroku-20 sync
 
-build: build-heroku-16 build-heroku-18 build-heroku-20
-
-build-heroku-16:
-	@docker pull heroku/heroku:16-build
-	@docker run -v "$(shell pwd)":/buildpack --rm -it -e "STACK=heroku-16" heroku/heroku:16-build /buildpack/scripts/build_ngx_mruby.sh
+build: build-heroku-18 build-heroku-20
 
 build-heroku-18:
 	@docker pull heroku/heroku:18-build

--- a/bin/compile
+++ b/bin/compile
@@ -9,11 +9,8 @@ env_dir=$3
 bp_dir=$(dirname $(dirname $0))
 
 case "${STACK}" in
-  heroku-16|heroku-18|heroku-20)
+  heroku-18|heroku-20)
     nginx_archive_url="https://heroku-buildpack-static.s3.amazonaws.com/${STACK}/nginx-1.19.0-ngx_mruby-2.2.3.tgz"
-    ;;
-  cedar-14)
-    nginx_archive_url='https://heroku-buildpack-ruby.s3.amazonaws.com/nginx/cedar-14/nginx-1.9.7-ngx_mruby.tgz'
     ;;
   *)
     echo "Stack ${STACK} is not supported!"


### PR DESCRIPTION
Since they are EOL and it's no longer possible to perform builds using them.

Closes #214.
GUS-W-10346704. 