### PR TITLE
Bump ngx_mruby/nginx versions and add support for Heroku-22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* [#239](https://github.com/heroku/heroku-buildpack-static/pull/239) Update ngx_mruby from 2.2.3 to 2.2.4.
+* [#239](https://github.com/heroku/heroku-buildpack-static/pull/239) Update nginx from 1.19.0 to 1.21.3.
+* [#239](https://github.com/heroku/heroku-buildpack-static/pull/239) Add support for Heroku-22.
 * [#238](https://github.com/heroku/heroku-buildpack-static/pull/238) Drop support for Cedar-14 and Heroku-16.
 
 ## v7 (2021-03-09)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 S3_BUCKET ?= heroku-buildpack-static
 
-.PHONY: build build-heroku-18 build-heroku-20 sync
+.PHONY: build build-heroku-18 build-heroku-20 build-heroku-22 sync
 
-build: build-heroku-18 build-heroku-20
+build: build-heroku-18 build-heroku-20 build-heroku-22
 
 build-heroku-18:
 	@docker pull heroku/heroku:18-build
@@ -11,6 +11,10 @@ build-heroku-18:
 build-heroku-20:
 	@docker pull heroku/heroku:20-build
 	@docker run -v "$(shell pwd)":/buildpack --rm -it -e "STACK=heroku-20" heroku/heroku:20-build /buildpack/scripts/build_ngx_mruby.sh
+
+build-heroku-22:
+	@docker pull heroku/heroku:22-build
+	@docker run -v "$(shell pwd)":/buildpack --rm -it -e "STACK=heroku-22" heroku/heroku:22-build /buildpack/scripts/build_ngx_mruby.sh
 
 sync:
 	@echo "Performing dry run of sync to $(S3_BUCKET)..."

--- a/bin/compile
+++ b/bin/compile
@@ -9,8 +9,8 @@ env_dir=$3
 bp_dir=$(dirname $(dirname $0))
 
 case "${STACK}" in
-  heroku-18|heroku-20)
-    nginx_archive_url="https://heroku-buildpack-static.s3.amazonaws.com/${STACK}/nginx-1.19.0-ngx_mruby-2.2.3.tgz"
+  heroku-18|heroku-20|heroku-22)
+    nginx_archive_url="https://heroku-buildpack-static.s3.amazonaws.com/${STACK}/nginx-1.21.3-ngx_mruby-2.2.4.tgz"
     ;;
   *)
     echo "Stack ${STACK} is not supported!"

--- a/scripts/build_ngx_mruby.sh
+++ b/scripts/build_ngx_mruby.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-NGX_MRUBY_VERSION='2.2.3'
+NGX_MRUBY_VERSION='2.2.4'
 NGX_MRUBY_URL="https://github.com/matsumotory/ngx_mruby/archive/v${NGX_MRUBY_VERSION}.tar.gz"
 
 echo "Building ngx_mruby v${NGX_MRUBY_VERSION} for ${STACK}"
@@ -18,7 +18,7 @@ echo "Downloading ngx_mruby from ${NGX_MRUBY_URL}"
 curl -sSfL "${NGX_MRUBY_URL}" | tar -xz --strip-components 1
 
 # Taken from the defaults:
-# https://github.com/matsumotory/ngx_mruby/blob/v2.2.3/build.sh#L23-L40
+# https://github.com/matsumotory/ngx_mruby/blob/v2.2.4/build.sh#L23-L40
 BUILD_OPTS="--prefix=${PWD}/build/nginx"
 BUILD_OPTS+=' --with-http_stub_status_module --with-stream --without-stream_access_module --with-cc-opt=-fno-common'
 # Our custom addition, to enable the SSL module.


### PR DESCRIPTION
In order to support Heroku-22 we need to generate new binaries, so it makes sense to build the latest versions for it and the other stacks rather than something outdated.

The binary build process for this buildpack uses the default `nginx` version specified by `ngx_mruby`. As such, updating `ngx_mruby` from `2.2.3` to `2.2.4` means the bundled `nginx` version is also updated from `1.19.0` to `1.21.3`:
https://github.com/matsumotory/ngx_mruby/blob/v2.2.3/nginx_version
https://github.com/matsumotory/ngx_mruby/blob/v2.2.4/nginx_version

Changes:
https://github.com/matsumotory/ngx_mruby/releases/tag/v2.2.4
https://nginx.org/en/CHANGES

GUS-W-10346704.