### PR TITLE
Update ngx_mruby to 2.2.4 and nginx to 1.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [#240](https://github.com/heroku/heroku-buildpack-static/pull/240) Update ngx_mruby from 2.2.3 to 2.2.4.
+* [#240](https://github.com/heroku/heroku-buildpack-static/pull/240) Update nginx from 1.19.0 to 1.21.3.
 * [#238](https://github.com/heroku/heroku-buildpack-static/pull/238) Drop support for Cedar-14 and Heroku-16.
 
 ## v7 (2021-03-09)

--- a/bin/compile
+++ b/bin/compile
@@ -10,7 +10,7 @@ bp_dir=$(dirname $(dirname $0))
 
 case "${STACK}" in
   heroku-18|heroku-20)
-    nginx_archive_url="https://heroku-buildpack-static.s3.amazonaws.com/${STACK}/nginx-1.19.0-ngx_mruby-2.2.3.tgz"
+    nginx_archive_url="https://heroku-buildpack-static.s3.amazonaws.com/${STACK}/nginx-1.21.3-ngx_mruby-2.2.4.tgz"
     ;;
   *)
     echo "Stack ${STACK} is not supported!"

--- a/scripts/build_ngx_mruby.sh
+++ b/scripts/build_ngx_mruby.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-NGX_MRUBY_VERSION='2.2.3'
+NGX_MRUBY_VERSION='2.2.4'
 NGX_MRUBY_URL="https://github.com/matsumotory/ngx_mruby/archive/v${NGX_MRUBY_VERSION}.tar.gz"
 
 echo "Building ngx_mruby v${NGX_MRUBY_VERSION} for ${STACK}"
@@ -18,7 +18,7 @@ echo "Downloading ngx_mruby from ${NGX_MRUBY_URL}"
 curl -sSfL "${NGX_MRUBY_URL}" | tar -xz --strip-components 1
 
 # Taken from the defaults:
-# https://github.com/matsumotory/ngx_mruby/blob/v2.2.3/build.sh#L23-L40
+# https://github.com/matsumotory/ngx_mruby/blob/v2.2.4/build.sh#L23-L40
 BUILD_OPTS="--prefix=${PWD}/build/nginx"
 BUILD_OPTS+=' --with-http_stub_status_module --with-stream --without-stream_access_module --with-cc-opt=-fno-common'
 # Our custom addition, to enable the SSL module.


### PR DESCRIPTION
The binary build process for this buildpack uses the default `nginx` version specified by `ngx_mruby`. As such, updating `ngx_mruby` from `2.2.3` to `2.2.4` means the bundled `nginx` version is also updated from `1.19.0` to `1.21.3`:
https://github.com/matsumotory/ngx_mruby/blob/v2.2.3/nginx_version
https://github.com/matsumotory/ngx_mruby/blob/v2.2.4/nginx_version

Changes:
https://github.com/matsumotory/ngx_mruby/releases/tag/v2.2.4
https://nginx.org/en/CHANGES

GUS-W-10346704.